### PR TITLE
Requirements, layout aspects, and flake8 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # cinder_volume_delete
 
+```
 usage: delete_volume.py [-h] CINDER_VOLUME_UUID
 
 This script will remove "stuck" cinder volumes. By stuck, that means they may
@@ -11,3 +12,20 @@ positional arguments:
 
 optional arguments:
   -h, --help          show this help message and exit
+```
+
+### Host Requirements
+
+Because of the usage of `MySQLdb`, this requires `libmysqlclient-dev` installed on the host in order to build the module.
+
+```
+sudo apt-get install -y libmysqlclient-dev
+```
+
+### Installing Python Requirements
+
+Install recommended in a virtualenv
+
+```
+pip install -r requirements.txt
+```

--- a/delete_volume.py
+++ b/delete_volume.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import MySQLdb

--- a/delete_volume.py
+++ b/delete_volume.py
@@ -5,62 +5,66 @@ import MySQLdb
 import argparse
 import ConfigParser
 
-parser = argparse.ArgumentParser(description='This script will remove "stuck" cinder volumes. By stuck, that means they may be stuck in detaching, deleting, etc. This script will remove the attachment and the volume in the database!')
-parser.add_argument('volume_uuid', metavar='CINDER_VOLUME_UUID',
-                    help='The UUID of the Cinder volume that needs to be removed')
-args = parser.parse_args()
-vol_uuid = args.volume_uuid
+def main():
+    parser = argparse.ArgumentParser(description='This script will remove "stuck" cinder volumes. By stuck, that means they may be stuck in detaching, deleting, etc. This script will remove the attachment and the volume in the database!')
+    parser.add_argument('volume_uuid', metavar='CINDER_VOLUME_UUID',
+                        help='The UUID of the Cinder volume that needs to be removed')
+    args = parser.parse_args()
+    vol_uuid = args.volume_uuid
+    
+    # Get connection info from /root/.my.cnf
+    
+    sql_ini_fileparser = ConfigParser.RawConfigParser()
+    sql_ini_fileparser.read('/root/.my.cnf')
+    host = sql_ini_fileparser.get('client', 'host')
+    user = sql_ini_fileparser.get('client', 'user')
+    password = sql_ini_fileparser.get('client', 'password')
+    
+    # Connect to MySQL and get cursor
+    db = MySQLdb.connect(host=host, user=user, passwd=password)
+    cursor = db.cursor()
+    
+    # DB queries
+    query1 = "UPDATE cinder.volumes SET attach_status='detached',deleted_at=NOW(),deleted=1,status='deleted',attach_status='detached',terminated_at=NOW() WHERE id='{}'".format(vol_uuid)
+    query2 = "UPDATE cinder.volume_attachment SET attach_status='detached', deleted=1, detach_time=NOW(), deleted_at=NOW() WHERE volume_id='{}'".format(vol_uuid)
+    query3 = "UPDATE cinder.volume_admin_metadata SET deleted=1, updated_at=NOW(), deleted_at=NOW() WHERE volume_id='{}' AND deleted=0".format(vol_uuid)
+    query4 = "UPDATE nova.block_device_mapping SET deleted=1, deleted_at=NOW() WHERE volume_id='{}'".format(vol_uuid)
+    
+    # Run DB queries
+    try:
+        cursor.execute(query1)
+        db.commit()
+    except:
+        db.rollback()
+    
+    try:
+        cursor.execute(query2)
+        db.commit()
+    except:
+        db.rollback()
+    
+    try:
+        cursor.execute(query3)
+        db.commit()
+    except:
+        db.rollback()
+    
+    try:
+        cursor.execute(query4)
+        db.commit()
+    except:
+        db.rollback()
+    
+    print('{} has been cleaned up in the database. Please verify the volume has been removed on the cinder backend.'.format(vol_uuid))
+    
+    # Get backend details
+    cursor.execute("""SELECT host from cinder.volumes WHERE id='{}'""".format(vol_uuid))
+    
+    backends = cursor.fetchone()
+    for backend in backends:
+        print('Backend Host: {}'.format(backend))
+    
+    db.close()
 
-# Get connection info from /root/.my.cnf
-
-sql_ini_fileparser = ConfigParser.RawConfigParser()
-sql_ini_fileparser.read('/root/.my.cnf')
-host = sql_ini_fileparser.get('client', 'host')
-user = sql_ini_fileparser.get('client', 'user')
-password = sql_ini_fileparser.get('client', 'password')
-
-# Connect to MySQL and get cursor
-db = MySQLdb.connect(host=host, user=user, passwd=password)
-cursor = db.cursor()
-
-# DB queries
-query1 = "UPDATE cinder.volumes SET attach_status='detached',deleted_at=NOW(),deleted=1,status='deleted',attach_status='detached',terminated_at=NOW() WHERE id='{}'".format(vol_uuid)
-query2 = "UPDATE cinder.volume_attachment SET attach_status='detached', deleted=1, detach_time=NOW(), deleted_at=NOW() WHERE volume_id='{}'".format(vol_uuid)
-query3 = "UPDATE cinder.volume_admin_metadata SET deleted=1, updated_at=NOW(), deleted_at=NOW() WHERE volume_id='{}' AND deleted=0".format(vol_uuid)
-query4 = "UPDATE nova.block_device_mapping SET deleted=1, deleted_at=NOW() WHERE volume_id='{}'".format(vol_uuid)
-
-# Run DB queries
-try:
-    cursor.execute(query1)
-    db.commit()
-except:
-    db.rollback()
-
-try:
-    cursor.execute(query2)
-    db.commit()
-except:
-    db.rollback()
-
-try:
-    cursor.execute(query3)
-    db.commit()
-except:
-    db.rollback()
-
-try:
-    cursor.execute(query4)
-    db.commit()
-except:
-    db.rollback()
-
-print('{} has been cleaned up in the database. Please verify the volume has been removed on the cinder backend.'.format(vol_uuid))
-
-# Get backend details
-cursor.execute("""SELECT host from cinder.volumes WHERE id='{}'""".format(vol_uuid))
-
-backends = cursor.fetchone()
-for backend in backends:
-    print('Backend Host: {}'.format(backend))
-
-db.close()
+if __name__ == '__main__':
+    sys.exit(main())

--- a/delete_volume.py
+++ b/delete_volume.py
@@ -5,66 +5,88 @@ import MySQLdb
 import argparse
 import ConfigParser
 
+
 def main():
-    parser = argparse.ArgumentParser(description='This script will remove "stuck" cinder volumes. By stuck, that means they may be stuck in detaching, deleting, etc. This script will remove the attachment and the volume in the database!')
+    desc = (
+        "This script will remove \"stuck\" cinder volumes. "
+        "By stuck, that means they may be stuck in detaching, "
+        "deleting, etc. This script will remove the attachment "
+        "and the volume in the database! ")
+    help_text = "The UUID of the Cinder volume that needs to be removed"
+    parser = argparse.ArgumentParser(description=desc)
     parser.add_argument('volume_uuid', metavar='CINDER_VOLUME_UUID',
-                        help='The UUID of the Cinder volume that needs to be removed')
+                        help=help_text)
     args = parser.parse_args()
     vol_uuid = args.volume_uuid
-    
+
     # Get connection info from /root/.my.cnf
-    
+
     sql_ini_fileparser = ConfigParser.RawConfigParser()
     sql_ini_fileparser.read('/root/.my.cnf')
     host = sql_ini_fileparser.get('client', 'host')
     user = sql_ini_fileparser.get('client', 'user')
     password = sql_ini_fileparser.get('client', 'password')
-    
+
     # Connect to MySQL and get cursor
     db = MySQLdb.connect(host=host, user=user, passwd=password)
     cursor = db.cursor()
-    
+
     # DB queries
-    query1 = "UPDATE cinder.volumes SET attach_status='detached',deleted_at=NOW(),deleted=1,status='deleted',attach_status='detached',terminated_at=NOW() WHERE id='{}'".format(vol_uuid)
-    query2 = "UPDATE cinder.volume_attachment SET attach_status='detached', deleted=1, detach_time=NOW(), deleted_at=NOW() WHERE volume_id='{}'".format(vol_uuid)
-    query3 = "UPDATE cinder.volume_admin_metadata SET deleted=1, updated_at=NOW(), deleted_at=NOW() WHERE volume_id='{}' AND deleted=0".format(vol_uuid)
-    query4 = "UPDATE nova.block_device_mapping SET deleted=1, deleted_at=NOW() WHERE volume_id='{}'".format(vol_uuid)
-    
+    query1 = (
+        "UPDATE cinder.volumes SET attach_status='detached',deleted_at=NOW(),"
+        "deleted=1,status='deleted',attach_status='detached',"
+        "terminated_at=NOW() WHERE id='{}'".format(vol_uuid))
+    query2 = (
+        "UPDATE cinder.volume_attachment SET attach_status='detached',"
+        "deleted=1, detach_time=NOW(), deleted_at=NOW() "
+        "WHERE volume_id='{}'".format(vol_uuid))
+    query3 = (
+        "UPDATE cinder.volume_admin_metadata SET deleted=1,"
+        "updated_at=NOW(), deleted_at=NOW() WHERE "
+        "volume_id='{}' AND deleted=0".format(vol_uuid))
+    query4 = (
+        "UPDATE nova.block_device_mapping SET deleted=1,"
+        "deleted_at=NOW() WHERE volume_id='{}'".format(vol_uuid))
+
     # Run DB queries
     try:
         cursor.execute(query1)
         db.commit()
-    except:
+    except Exception as e:
         db.rollback()
-    
+
     try:
         cursor.execute(query2)
         db.commit()
-    except:
+    except Exception as e:
         db.rollback()
-    
+
     try:
         cursor.execute(query3)
         db.commit()
-    except:
+    except Exception as e:
         db.rollback()
-    
+
     try:
         cursor.execute(query4)
         db.commit()
-    except:
+    except Exception as e:
         db.rollback()
-    
-    print('{} has been cleaned up in the database. Please verify the volume has been removed on the cinder backend.'.format(vol_uuid))
-    
+
+    resp = ("{} has been cleaned up in the database. "
+            "Please verify the volume has been removed "
+            "on the cinder backend.").format(vol_uuid)
+    print(resp)
+
     # Get backend details
-    cursor.execute("""SELECT host from cinder.volumes WHERE id='{}'""".format(vol_uuid))
-    
+    cursor.execute(
+        "SELECT host from cinder.volumes WHERE id='{}'".format(vol_uuid))
+
     backends = cursor.fetchone()
     for backend in backends:
         print('Backend Host: {}'.format(backend))
-    
     db.close()
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+configparser==3.5.0
+MySQL-python==1.2.5


### PR DESCRIPTION
I haven't adjusted or reviewed any of the logic here, the only adjustments here have to do with pep8 style suggestions, adding a requirement file for testing, and adding the `__main__` namespace declaration. 

Flake8 is still complain about unreferenced variable `e` in the exception clause, but it was either that or have flake8 complain about the exception being generically called so I figured this was the lesser of two evils (less flake8 complaint lines). 

I tested against my lab, but further testing to make sure the behavior works as originally expected would be useful before the merge. Like I said, no logic should have changed.